### PR TITLE
Correcting typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Grunt should load the config options from your Dalekfile
 
 #### options.browser
 Type: `Array`
-Default: `['phatnomjs']`
+Default: `['phantomjs']`
 
 The browsers you would like to test
 Note: For other browsers than PhantomJS, you need to have the Dalek browser plugin installed.


### PR DESCRIPTION
Since it is for a possible options property value, it's great to correct it :)
